### PR TITLE
Fix README typos

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ blocksizecol = 96;
 Verical overlap between blocks
 blockrowoverlap = 0;
 Horizontal overlap between blocks
-blockcoleoverlap = 0;
+blockcoloverlap = 0;
 The sharpness threshold level
 sh_th        = 0.75;
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,9 +115,9 @@ blocksizerow = 96;
 Width of the block
 blocksizecol = 96;
 Verical overlap between blocks
-blocksizerow = 0;
+blocksizeoverlap = 0;
 Horizontal overlap between blocks
-blocksizecol = 0;
+blocksizeoverlap = 0;
 The sharpness threshold level
 sh_th        = 0.75;
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,4 +124,3 @@ sh_th        = 0.75;
 
 [mu_prisparam cov_prisparam]  = estimatemodelparam(folderpath,blocksizerow,blocksizecol,blockrowoverlap,blockcoloverlap,sh_th)
 =======================================================================
- 

--- a/readme.txt
+++ b/readme.txt
@@ -115,9 +115,9 @@ blocksizerow = 96;
 Width of the block
 blocksizecol = 96;
 Verical overlap between blocks
-blocksizeoverlap = 0;
+blockrowoverlap = 0;
 Horizontal overlap between blocks
-blocksizeoverlap = 0;
+blockcoleoverlap = 0;
 The sharpness threshold level
 sh_th        = 0.75;
 


### PR DESCRIPTION
In the README file, the instructions for retraining the model using new images defines `blocksizerow` and `blocksizecol` twice, but never defines `blockcoloverlap` and `blockrowoverlap`.